### PR TITLE
sitemap.xml 商品が大量の場合の対応

### DIFF
--- a/src/Eccube/Resource/template/default/sitemap_index.xml.twig
+++ b/src/Eccube/Resource/template/default/sitemap_index.xml.twig
@@ -8,8 +8,10 @@
         <loc>{{url('sitemap_category_xml')}}</loc>
         <lastmod>{{Category.update_date|date_format('','c')}}</lastmod>
     </sitemap>
-    <sitemap>
-        <loc>{{url('sitemap_product_xml')}}</loc>
-        <lastmod>{{Product.update_date|date_format('','c')}}</lastmod>
-    </sitemap>
+    {% for p in 1..ProductPageCount %}
+        <sitemap>
+            <loc>{{url('sitemap_product_xml', {page: p})}}</loc>
+            <lastmod>{{Product.update_date|date_format('','c')}}</lastmod>
+        </sitemap>
+    {% endfor %}
 </sitemapindex>

--- a/tests/Eccube/Tests/Web/SitemapControllerTest.php
+++ b/tests/Eccube/Tests/Web/SitemapControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Web;
+
+class SitemapControllerTest extends AbstractWebTestCase
+{
+    public function testIndex()
+    {
+        $this->client->request('GET', $this->generateUrl('sitemap_xml'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testProduct()
+    {
+        $this->client->request('GET', $this->generateUrl('sitemap_product_xml', ['page' => 1]));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testCategory()
+    {
+        $this->client->request('GET', $this->generateUrl('sitemap_category_xml'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+
+    public function testPage()
+    {
+        $this->client->request('GET', $this->generateUrl('sitemap_page_xml'));
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+    }
+}


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
sitemap_product.xml ですが、商品点数が非常に多い場合はメモリ不足になる懸念がありましたので、
1000件ずつページを分けるような処理をいれました。
ご確認いただけましたらと思います。

refs EC-CUBE#4808

## 方針(Policy)

## 実装に関する補足(Appendix)

## テスト（Test)

## 相談（Discussion）

## マイナーバージョン互換性保持のための制限事項チェックリスト

- [ ] 既存機能の仕様変更
- [ ] フックポイントの呼び出しタイミングの変更
- [ ] フックポイントのパラメータの削除・データ型の変更
- [ ] twigファイルに渡しているパラメータの削除・データ型の変更
- [ ] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [ ] 入出力ファイル(CSVなど)のフォーマット変更



